### PR TITLE
fix: bot will no longer throw exception when receive media content

### DIFF
--- a/app/src/main/java/MochiMochiTalk/voice/nvoice/EventListenerForTTS.java
+++ b/app/src/main/java/MochiMochiTalk/voice/nvoice/EventListenerForTTS.java
@@ -98,6 +98,11 @@ public class EventListenerForTTS extends ListenerAdapter {
         }
 
         if(flag && !rawContent.startsWith(App.getStaticPrefix())) {
+            // early return for not speaking media content
+            if(!message.getAttachments().isEmpty()) {
+                log.info("Message contains media content. : {}", content);
+                return;
+            }
             String immutableContent = content;
             CompletableFuture<Optional<String>> dictFetchFuture = CompletableFuture.supplyAsync(() -> {
                 CommandDictionary instance = CommandDictionary.getInstance();


### PR DESCRIPTION
# Pull Request

## Current behavior
- fixes: #26 

## New behavior
- Bot will avoid processing message when message contains some media files
