### PR TITLE
Release v6.0.7

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
 
     // logback
-    implementation('ch.qos.logback:logback-classic:1.4.14')
+    implementation('ch.qos.logback:logback-classic:1.5.0')
 
     // implementation 'com.google.cloud:google-cloud-speech:2.2.2'
     // implementation 'com.google.cloud:google-cloud-texttospeech:2.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation group: 'com.google.cloud', name: 'google-cloud-texttospeech', version: '2.35.0'
 
 // https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http
-    implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.22.0'
+    implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.23.0'
 
 // google drive api
     implementation group: 'com.google.apis', name: 'google-api-services-drive', version: 'v3-rev20240123-2.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation group: 'com.google.api-client', name: 'google-api-client', version: '2.3.0'
 
 // https://mvnrepository.com/artifact/com.google.cloud/google-cloud-texttospeech
-    implementation group: 'com.google.cloud', name: 'google-cloud-texttospeech', version: '2.35.0'
+    implementation group: 'com.google.cloud', name: 'google-cloud-texttospeech', version: '2.37.0'
 
 // https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http
     implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.23.0'

--- a/app/src/main/resources/description.json
+++ b/app/src/main/resources/description.json
@@ -4,5 +4,5 @@
   "bugfix": "バグ修正はありません。",
   "bugs": "今後、いくつかのコマンドにてより直感的に操作が出来るよう改良を行う予定です。",
   "Developer": "Ranfa/hizumiaoba/Indigo_leaF P#4144",
-  "version": "MochiMochiTalk-v6.0.6"
+  "version": "MochiMochiTalk-v6.0.7"
 }


### PR DESCRIPTION
- chore(deps): bump ch.qos.logback:logback-classic in /app (#181)
- chore(deps): bump com.google.auth:google-auth-library-oauth2-http (#179)
- chore(deps): bump com.google.cloud:google-cloud-texttospeech in /app (#182)
- chore: increment version to v6.0.7
