### PR TITLE
Release v6.0.8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.23.0'
 
 // google drive api
-    implementation group: 'com.google.apis', name: 'google-api-services-drive', version: 'v3-rev20240123-2.0.0'
+    implementation group: 'com.google.apis', name: 'google-api-services-drive', version: 'v3-rev20240327-2.0.0'
 
 // libraries for regex matching
     implementation group: 'com.google.re2j', name: 're2j', version: '1.7'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     // implementation 'com.github.wdavies973:VocalCord:2.3'
 
     // https://mvnrepository.com/artifact/com.google.api-client/google-api-client
-    implementation group: 'com.google.api-client', name: 'google-api-client', version: '2.4.0'
+    implementation group: 'com.google.api-client', name: 'google-api-client', version: '2.4.1'
 
 // https://mvnrepository.com/artifact/com.google.cloud/google-cloud-texttospeech
     implementation group: 'com.google.cloud', name: 'google-cloud-texttospeech', version: '2.42.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 ext {
-  jacksonVersion = "2.16.1"
+  jacksonVersion = "2.17.0"
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation group: 'com.google.api-client', name: 'google-api-client', version: '2.4.0'
 
 // https://mvnrepository.com/artifact/com.google.cloud/google-cloud-texttospeech
-    implementation group: 'com.google.cloud', name: 'google-cloud-texttospeech', version: '2.37.0'
+    implementation group: 'com.google.cloud', name: 'google-cloud-texttospeech', version: '2.42.0'
 
 // https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http
     implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.23.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 
     // This dependency is used by the application.
-    implementation 'com.google.guava:guava:33.0.0-jre'
+    implementation 'com.google.guava:guava:33.1.0-jre'
 
     // Java Discord API
     // https://mvnrepository.com/artifact/net.dv8tion/JDA

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
     // Java Discord API
     // https://mvnrepository.com/artifact/net.dv8tion/JDA
-    implementation group: 'net.dv8tion', name: 'JDA', version: '5.0.0-beta.20'
+    implementation group: 'net.dv8tion', name: 'JDA', version: '5.0.0-beta.22'
 
 
     // logback

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
 
     // logback
-    implementation('ch.qos.logback:logback-classic:1.5.4')
+    implementation('ch.qos.logback:logback-classic:1.5.5')
 
     // implementation 'com.google.cloud:google-cloud-speech:2.2.2'
     // implementation 'com.google.cloud:google-cloud-texttospeech:2.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
 
     // logback
-    implementation('ch.qos.logback:logback-classic:1.5.0')
+    implementation('ch.qos.logback:logback-classic:1.5.3')
 
     // implementation 'com.google.cloud:google-cloud-speech:2.2.2'
     // implementation 'com.google.cloud:google-cloud-texttospeech:2.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     // implementation 'com.github.wdavies973:VocalCord:2.3'
 
     // https://mvnrepository.com/artifact/com.google.api-client/google-api-client
-    implementation group: 'com.google.api-client', name: 'google-api-client', version: '2.3.0'
+    implementation group: 'com.google.api-client', name: 'google-api-client', version: '2.4.0'
 
 // https://mvnrepository.com/artifact/com.google.cloud/google-cloud-texttospeech
     implementation group: 'com.google.cloud', name: 'google-cloud-texttospeech', version: '2.37.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
     // Java Discord API
     // https://mvnrepository.com/artifact/net.dv8tion/JDA
-    implementation group: 'net.dv8tion', name: 'JDA', version: '5.0.0-beta.22'
+    implementation group: 'net.dv8tion', name: 'JDA', version: '5.0.0-beta.23'
 
 
     // logback

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,11 +76,11 @@ dependencies {
     implementation(fileTree(dir: '..\\native', include: ['hajimeapi4j.jar']))
 
     // Lombok
-    implementation 'org.projectlombok:lombok:1.18.30'
-    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    implementation 'org.projectlombok:lombok:1.18.32'
+    annotationProcessor 'org.projectlombok:lombok:1.18.32'
 
-    testImplementation 'org.projectlombok:lombok:1.18.30'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
+    testImplementation 'org.projectlombok:lombok:1.18.32'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.32'
 }
 
 application {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
 
     // logback
-    implementation('ch.qos.logback:logback-classic:1.5.3')
+    implementation('ch.qos.logback:logback-classic:1.5.4')
 
     // implementation 'com.google.cloud:google-cloud-speech:2.2.2'
     // implementation 'com.google.cloud:google-cloud-texttospeech:2.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
 
     // logback
-    implementation('ch.qos.logback:logback-classic:1.5.5')
+    implementation('ch.qos.logback:logback-classic:1.5.6')
 
     // implementation 'com.google.cloud:google-cloud-speech:2.2.2'
     // implementation 'com.google.cloud:google-cloud-texttospeech:2.1.1'

--- a/app/src/main/resources/description.json
+++ b/app/src/main/resources/description.json
@@ -4,5 +4,5 @@
   "bugfix": "バグ修正はありません。",
   "bugs": "今後、いくつかのコマンドにてより直感的に操作が出来るよう改良を行う予定です。",
   "Developer": "Ranfa/hizumiaoba/Indigo_leaF P#4144",
-  "version": "MochiMochiTalk-v6.0.7"
+  "version": "MochiMochiTalk-v6.0.8"
 }


### PR DESCRIPTION
- chore(deps): bump ch.qos.logback:logback-classic in /app (#186)
- chore(deps): bump org.projectlombok:lombok in /app (#193)
- chore(deps): bump net.dv8tion:JDA in /app (#199)
- chore(deps): bump ch.qos.logback:logback-classic in /app (#200)
- chore(deps): bump jacksonVersion from 2.16.1 to 2.17.0 in /app (#190)
- chore(deps): bump com.google.guava:guava in /app (#191)
- chore(deps): bump com.google.api-client:google-api-client in /app (#192)
- chore(deps): bump com.google.cloud:google-cloud-texttospeech in /app (#198)
- chore(deps): bump com.google.apis:google-api-services-drive in /app (#201)
- chore(deps): bump ch.qos.logback:logback-classic in /app (#202)
- chore(deps): bump net.dv8tion:JDA in /app (#204)
- chore(deps): bump com.google.api-client:google-api-client in /app (#205)
- chore(deps): bump ch.qos.logback:logback-classic in /app (#203)
- chore: increment version to v6.0.8
