### PR TITLE
ci: brush up action workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     branches:
       - main
-    branches-ignore:
-      - release/*
+      - '!release/*'
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,13 +17,9 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      - name: Setup  Gradle
+        uses: gradle/actions/setup-gradle@v5
       - name: Grant execution permission for gradlew
         run: chmod +x ./gradlew
-      - name: Gradle actions
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: |
-            build
-            -i
-            --stacktrace
-            
+      - name: Build with Gradle
+        run: ./gradlew build -i --stacktrace

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,10 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   gradle:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  merge_group:
-    branch:
-      - main
     branch-ignore:
       - release/*
 concurrency:
@@ -16,21 +13,21 @@ jobs:
   gradle:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Grant execution permission for gradlew
         run: chmod +x ./gradlew ./gradlew.bat
       - name: Gradle actions
         uses: gradle/gradle-build-action@v3
         with:
           arguments: |
-            test
+            build
             -i
             --stacktrace
             

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Grant execution permission for gradlew
-        run: chmod +x ./gradlew ./gradlew.bat
+        run: chmod +x ./gradlew
       - name: Gradle actions
         uses: gradle/gradle-build-action@v3
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-    branch-ignore:
+    branches-ignore:
       - release/*
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
- remove the merge queue
- remove unnecessary runner OSes
- bump up Java version to 17
- change build arguments to “build”
